### PR TITLE
Polyscope slicer and visualization of the ASO scalar field as example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 # Create an executable
 add_executable( poncascope
                 src/poncaAdapters.hpp
+                src/polyscopeSlicer.hpp
                 src/main.cpp
                 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,13 +258,6 @@ Scalar evalScalarField_impl(const VectorType& input_pos)
     return current_value;
 }
 
-/// Compute curvature using Algebraic Shape Operator
-/// \see estimateDifferentialQuantities_impl
-inline Scalar evalScalarFieldWithASO(const VectorType& input_pos) {
-    return evalScalarField_impl<FitASO>(input_pos);
-}
-
-
 /// Define Polyscope callbacks
 void callback() {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,11 +300,18 @@ void callback() {
     ImGui::RadioButton("X axis", &axis, 0); ImGui::SameLine();
     ImGui::RadioButton("Y axis", &axis, 1); ImGui::SameLine();
     ImGui::RadioButton("Z axis", &axis, 2);
+    const char* items[] = { "ASO", "APSS", "PSS"};
+    static int item_current = 0;
+    ImGui::Combo("Fit function", &item_current, items, IM_ARRAYSIZE(items));
     if (ImGui::Button("Update"))
     {
       VectorType lower(-2,-2,-2),upper(2,2,2);
-      auto mySlicer = registerRegularSlicer("slicer", evalScalarFieldWithASO,lower, upper,
-                                            isHDSlicer?1024:256, axis, slice);
+      switch(item_current)
+      {
+        case 0: registerRegularSlicer("slicer", evalScalarField_impl<FitASO>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
+        case 1: registerRegularSlicer("slicer", evalScalarField_impl<FitAPSS>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
+        case 2: registerRegularSlicer("slicer", evalScalarField_impl<FitPlane>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
+      }
     }
     ImGui::SameLine();
     ImGui::PopItemWidth();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,8 +40,8 @@ bool useKnnGraph   = false; /// < use k-neighbor graph instead of kdtree
 
 
 // Slicer
-float slice;
-int axis;
+float slice    = 0.f;
+int axis       = 0;
 bool isHDSlicer=false;
 
 /// Convenience function measuring and printing the processing time of F

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <Ponca/Fitting>
 #include <Ponca/SpatialPartitioning>
 #include "poncaAdapters.hpp"
+#include "polyscopeSlicer.hpp"
 
 #include <iostream>
 #include <utility>
@@ -37,6 +38,11 @@ int mlsIter        = 3;     /// < number of moving least squares iterations
 Scalar pointRadius = 0.005; /// < display radius of the point cloud
 bool useKnnGraph   = false; /// < use k-neighbor graph instead of kdtree
 
+
+// Slicer
+float slice;
+int axis;
+bool isHDSlicer=false;
 
 /// Convenience function measuring and printing the processing time of F
 template <typename Functor>
@@ -224,6 +230,41 @@ void mlsDryRun() {
     });
 }
 
+///Evaluate the ASO scalar field evaluation.
+Scalar eval_scalar_field_ASO(const VectorType& input_pos)
+{
+  using FitASO = Ponca::BasketDiff<
+  Ponca::Basket<
+  PPAdapter,
+  SmoothWeightFunc,
+  Ponca::OrientedSphereFit>,
+  Ponca::DiffType::FitSpaceDer,
+  Ponca::OrientedSphereDer,
+  Ponca::MlsSphereFitDer,
+  Ponca::CurvatureEstimatorBase,
+  Ponca::NormalDerivativesCurvatureEstimator>;
+  VectorType current_pos = input_pos;
+  Scalar current_value = std::numeric_limits<Scalar>::max();
+  for(int mm = 0; mm < mlsIter; ++mm)
+  {
+    FitASO fit;
+    fit.setWeightFunc(SmoothWeightFunc(NSize));
+    fit.init(current_pos); // weighting function using current pos (not input pos)
+    for(int j : tree.range_neighbors(current_pos, NSize)) {
+      fit.addNeighbor(tree.point_data()[j]);
+    }
+    if(fit.finalize() == Ponca::STABLE) {
+      current_pos = fit.project(input_pos); // always project input pos
+      current_value = fit.potential(input_pos);
+      // current_gradient = fit.primitiveGradient(input_pos);
+    } else {
+      // not enough neighbors (if far from the point cloud)
+      return .0;//std::numeric_limits<Scalar>::max();
+    }
+  }
+  return current_value;
+}
+
 
 /// Define Polyscope callbacks
 void callback() {
@@ -253,13 +294,26 @@ void callback() {
     if (ImGui::Button("APSS")) estimateDifferentialQuantitiesWithAPSS();
     ImGui::SameLine();
     if (ImGui::Button("ASO")) estimateDifferentialQuantitiesWithASO();
-
+    
+    ImGui::Separator();
+    ImGui::SliderFloat("Slice", &slice, 0, 1.0); ImGui::SameLine();
+    ImGui::Checkbox("HD", &isHDSlicer);
+    ImGui::RadioButton("X axis", &axis, 0); ImGui::SameLine();
+    ImGui::RadioButton("Y axis", &axis, 1); ImGui::SameLine();
+    ImGui::RadioButton("Z axis", &axis, 2);
+    if (ImGui::Button("Update"))
+    {
+      VectorType lower(-2,-2,-2),upper(2,2,2);
+      auto mySlicer = registerRegularSlicer("slicer", eval_scalar_field_ASO,lower, upper,
+                                            isHDSlicer?1024:256, axis, slice);
+    }
+    ImGui::SameLine();
     ImGui::PopItemWidth();
 }
 
 int main(int argc, char **argv) {
     // Options
-    polyscope::options::autocenterStructures = true;
+    polyscope::options::autocenterStructures = false;
     polyscope::options::programName = "poncascope";
     polyscope::view::windowWidth = 1024;
     polyscope::view::windowHeight = 1024;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,9 +40,9 @@ Scalar pointRadius = 0.005; /// < display radius of the point cloud
 bool useKnnGraph   = false; /// < use k-neighbor graph instead of kdtree
 
 // Slicer
-int slice;
+float slice;
 int axis;
-
+bool isHDSlicer=false;
 
 /// Convenience function measuring and printing the processing time of F
 template <typename Functor>
@@ -230,6 +230,39 @@ void mlsDryRun() {
     });
 }
 
+Scalar eval_scalar_field_ASO(const VectorType& input_pos)
+{
+  using FitASO = Ponca::BasketDiff<
+  Ponca::Basket<
+  PPAdapter,
+  SmoothWeightFunc,
+  Ponca::OrientedSphereFit>,
+  Ponca::DiffType::FitSpaceDer,
+  Ponca::OrientedSphereDer,
+  Ponca::MlsSphereFitDer,
+  Ponca::CurvatureEstimatorBase,
+  Ponca::NormalDerivativesCurvatureEstimator>;
+  VectorType current_pos = input_pos;
+  Scalar current_value = std::numeric_limits<Scalar>::max();
+  for(int mm = 0; mm < mlsIter; ++mm)
+  {
+    FitASO fit;
+    fit.setWeightFunc(SmoothWeightFunc(NSize));
+    fit.init(current_pos); // weighting function using current pos (not input pos)
+    for(int j : tree.range_neighbors(current_pos, NSize)) {
+      fit.addNeighbor(tree.point_data()[j]);
+    }
+    if(fit.finalize() == Ponca::STABLE) {
+      current_pos = fit.project(input_pos); // always project input pos
+      current_value = fit.potential(input_pos);
+      // current_gradient = fit.primitiveGradient(input_pos);
+    } else {
+      // not enough neighbors (if far from the point cloud)
+      return .0;//std::numeric_limits<Scalar>::max();
+    }
+  }
+  return current_value;
+}
 
 /// Define Polyscope callbacks
 void callback() {
@@ -261,52 +294,16 @@ void callback() {
     if (ImGui::Button("ASO")) estimateDifferentialQuantitiesWithASO();
 
     ImGui::Separator();
-    ImGui::SliderInt("Slice / 1024", &slice, 0, 1024);
+    ImGui::SliderFloat("Slice", &slice, 0, 1.0); ImGui::SameLine();
+    ImGui::Checkbox("HD", &isHDSlicer);
     ImGui::RadioButton("X axis", &axis, 0); ImGui::SameLine();
     ImGui::RadioButton("Y axis", &axis, 1); ImGui::SameLine();
     ImGui::RadioButton("Z axis", &axis, 2);
     if (ImGui::Button("Update"))
     {
-      //tmp
-      auto eval_scalar_field_ASO = [&](const VectorType& input_pos) -> Scalar
-      {
-        using FitASO = Ponca::BasketDiff<
-        Ponca::Basket<
-        PPAdapter,
-        SmoothWeightFunc,
-        Ponca::OrientedSphereFit>,
-        Ponca::DiffType::FitSpaceDer,
-        Ponca::OrientedSphereDer,
-        Ponca::MlsSphereFitDer,
-        Ponca::CurvatureEstimatorBase,
-        Ponca::NormalDerivativesCurvatureEstimator>;
-        VectorType current_pos = input_pos;
-        Scalar current_value = std::numeric_limits<Scalar>::max();
-        for(int mm = 0; mm < mlsIter; ++mm)
-        {
-          FitASO fit;
-          fit.setWeightFunc(SmoothWeightFunc(NSize));
-          fit.init(current_pos); // weighting function using current pos (not input pos)
-          for(int j : tree.range_neighbors(current_pos, NSize)) {
-            fit.addNeighbor(tree.point_data()[j]);
-          }
-          //std::cout<<"Final : "<<fit.finalize()<<" "<<NSize<<std::endl;
-          if(fit.finalize() == Ponca::STABLE) {
-            current_pos = fit.project(input_pos); // always project input pos
-            current_value = fit.potential(input_pos);
-            // current_gradient = fit.primitiveGradient(input_pos);
-          } else {
-            // not enough neighbors (if far from the point cloud)
-            return .0;//std::numeric_limits<Scalar>::max();
-          }
-        }
-        return current_value;
-      };
-      
       VectorType lower(-2,-2,-2),upper(2,2,2);
-      auto distX= [](const VectorType &v){ return v[0];};
-      auto  mySlicer = makeSlicer("slicer",eval_scalar_field_ASO,lower, upper, 1024,axis);
-      mySlicer.regiterSlicer(slice);
+      auto mySlicer = registerRegularSlicer("slicer", eval_scalar_field_ASO,lower, upper,
+                                            isHDSlicer?1024:256, axis, slice);
     }
     ImGui::SameLine();
     ImGui::PopItemWidth();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,10 +38,13 @@ Scalar pointRadius = 0.005; /// < display radius of the point cloud
 bool useKnnGraph   = false; /// < use k-neighbor graph instead of kdtree
 
 
+
 // Slicer
 float slice    = 0.f;
 int axis       = 0;
 bool isHDSlicer=false;
+VectorType lower, upper;
+
 
 /// Convenience function measuring and printing the processing time of F
 template <typename Functor>
@@ -300,7 +303,6 @@ void callback() {
     ImGui::Combo("Fit function", &item_current, items, IM_ARRAYSIZE(items));
     if (ImGui::Button("Update"))
     {
-      VectorType lower(-2,-2,-2),upper(2,2,2);
       switch(item_current)
       {
         case 0: registerRegularSlicer("slicer", evalScalarField_impl<FitASO>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
@@ -339,6 +341,10 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
+    //Bounding Box (used in the slicer)
+    lower = cloudV.colwise().minCoeff();
+    upper = cloudV.colwise().maxCoeff();
+  
     // Build Ponca KdTree
     measureTime( "[Ponca] Build KdTree", []() {
         buildKdTree(cloudV, cloudN, tree);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,6 @@
 #include <igl/readOBJ.h>
 #include <igl/per_vertex_normals.h>
 
-#include "polyscope/messages.h"
 #include "polyscope/point_cloud.h"
 
 #include <Ponca/Fitting>
@@ -116,11 +115,8 @@ void colorizeKnn() {
 /// \note Functor is called only if fit is stable
 template<typename FitT, typename Functor>
 void processPointCloud(const typename FitT::WeightFunction& w, Functor f){
-
-    int nvert = tree.index_data().size();
-
 #pragma omp parallel for
-    for (int i = 0; i < nvert; ++i) {
+    for (int i = 0; i < tree.index_data().size(); ++i) {
         VectorType pos = tree.point_data()[i].pos();
 
         for( int mm = 0; mm < mlsIter; ++mm) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,6 +295,8 @@ void callback() {
     if (ImGui::Button("ASO")) estimateDifferentialQuantitiesWithASO();
     
     ImGui::Separator();
+  
+    ImGui::Text("Implicit function slicer");
     ImGui::SliderFloat("Slice", &slice, 0, 1.0); ImGui::SameLine();
     ImGui::Checkbox("HD", &isHDSlicer);
     ImGui::RadioButton("X axis", &axis, 0); ImGui::SameLine();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,7 +238,7 @@ inline void mlsDryRun() {
 
 ///Evaluate scalar field for generic FitType.
 ///// \tparam FitT Defines the type of estimator used for computation
-template<typename FitT>
+template<typename FitT, bool isSigned = true>
 Scalar evalScalarField_impl(const VectorType& input_pos)
 {
     VectorType current_pos = input_pos;
@@ -251,7 +251,7 @@ Scalar evalScalarField_impl(const VectorType& input_pos)
             auto res = fit.computeWithIds(tree.range_neighbors(current_pos, NSize), tree.point_data());
             if(res == Ponca::STABLE) {
             current_pos = fit.project(input_pos); // always project input pos
-            current_value = fit.potential(input_pos);
+            current_value = isSigned ? fit.potential(input_pos) : std::abs(fit.potential(input_pos));
             // current_gradient = fit.primitiveGradient(input_pos);
         } else {
             // not enough neighbors (if far from the point cloud)
@@ -305,9 +305,9 @@ void callback() {
     {
       switch(item_current)
       {
-        case 0: registerRegularSlicer("slicer", evalScalarField_impl<FitASO>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
-        case 1: registerRegularSlicer("slicer", evalScalarField_impl<FitAPSS>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
-        case 2: registerRegularSlicer("slicer", evalScalarField_impl<FitPlane>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
+        case 0: registerRegularSlicer("slicer", evalScalarField_impl<FitASO, true>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
+        case 1: registerRegularSlicer("slicer", evalScalarField_impl<FitAPSS, true>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
+        case 2: registerRegularSlicer("slicer", evalScalarField_impl<FitPlane, false>,lower, upper, isHDSlicer?1024:256, axis, slice); break;
       }
     }
     ImGui::SameLine();

--- a/src/polyscopeSlicer.hpp
+++ b/src/polyscopeSlicer.hpp
@@ -99,7 +99,7 @@ polyscope::SurfaceMesh* registerRegularSlicer(const std::string &name,
   
   //Evaluating the mplicit function (in parallel using openmp)
 #pragma omp parallel for
-  for(size_t id=0; id < nbSteps*nbSteps; ++id)
+  for(int id=0; id < nbSteps*nbSteps; ++id)
     values[id]  = implicit(vertices[id]);
 
   //Polyscope registration

--- a/src/polyscopeSlicer.hpp
+++ b/src/polyscopeSlicer.hpp
@@ -97,8 +97,8 @@ polyscope::SurfaceMesh* registerRegularSlicer(const std::string &name,
       faces.push_back(face);
   }
   
-  //Evaluating the mplicit function (in parallel using openmp)
-#pragma omp parallel for
+  //Evaluating the implicit function (in parallel using openmp)
+#pragma omp parallel for default(none) shared(nbSteps,values,vertices,implicit)
   for(int id=0; id < nbSteps*nbSteps; ++id)
     values[id]  = implicit(vertices[id]);
 

--- a/src/polyscopeSlicer.hpp
+++ b/src/polyscopeSlicer.hpp
@@ -1,0 +1,127 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <polyscope/surface_mesh.h>
+#include <polyscope/polyscope.h>
+
+template<typename Point,typename Functor>
+struct PolyscopeSlicer
+{
+  
+  Functor  _implicit;
+  Point _lowerBound;
+  Point _upperBound;
+  size_t _nbSteps;
+  size_t _axis;
+  size_t _slice;
+  std::string _name;
+  
+  PolyscopeSlicer(std::string name,
+                  Functor &implicit,
+                  const Point &lowerBound,
+                  const Point &upperBound,
+                  size_t nbSteps,
+                  size_t axis): _name(name),_implicit(implicit),_lowerBound(lowerBound),
+  _upperBound(upperBound),_nbSteps(nbSteps),_axis(axis)
+  {
+  }
+    
+  polyscope::SurfaceMesh* regiterSlicer(size_t slice=0)
+  {
+    _slice = slice;
+    auto dim1 = (_axis+1)%3;
+    auto dim2 = (_axis+2)%3;
+    
+    double du = (_upperBound[dim1]-_lowerBound[dim1])/(double)_nbSteps;
+    double dv = (_upperBound[dim2]-_lowerBound[dim2])/(double)_nbSteps;
+    double dw = (_upperBound[_axis]-_lowerBound[_axis])/(double)_nbSteps;
+    
+    double u = _lowerBound[dim1];
+    double v = _lowerBound[dim2];
+    double w = _lowerBound[_axis] + _slice*dw;
+    
+    Point p;
+    Point vu,vv;
+    switch (_axis) {
+      case 0: p=Point(w,u,v); vu=Point(0,du,0); vv=Point(0,0,dv);break;
+      case 1: p=Point(u,w,v); vu=Point(du,0,0); vv=Point(0,0,dv);break;
+      case 2: p=Point(u,v,w); vu=Point(du,0,0); vv=Point(0,dv,0);break;
+    }
+    
+    std::vector<Point> vertices(_nbSteps*_nbSteps);
+    std::vector<double> values(_nbSteps*_nbSteps);
+    std::vector<std::array<size_t,4>> faces;
+    std::array<size_t,4> face;
+    
+    for(size_t id=0; id < _nbSteps*_nbSteps; ++id)
+    {
+      auto i = id % _nbSteps;
+      auto j = id / _nbSteps;
+      p = _lowerBound + i*vu + j*vv;
+      p[_axis] += _slice*dw;
+      
+      vertices[id] = p;
+      values[id]  = _implicit(p);
+      face = { id, id+1, id+1+_nbSteps, id+_nbSteps };
+      if (((i+1) < _nbSteps) && ((j+1)<_nbSteps))
+        faces.push_back(face);
+    }
+    std::cout<<"vertices: "<<vertices.size()<<std::endl;
+    auto psm = polyscope::registerSurfaceMesh(_name, vertices,faces);
+    psm->addVertexScalarQuantity("values",values)->setEnabled(true);
+    return psm;
+  }
+  
+  
+  void updateSlice(size_t slice)
+  {
+    auto dim1 = (_axis+1)%3;
+    auto dim2 = (_axis+2)%3;
+    double du = (_upperBound[dim1]-_lowerBound[dim1])/(double)_nbSteps;
+    double dv = (_upperBound[dim2]-_lowerBound[dim2])/(double)_nbSteps;
+    double dw = (_upperBound[_axis]-_lowerBound[_axis])/(double)_nbSteps;
+    double u = _lowerBound[dim1];
+    double v = _lowerBound[dim2];
+    double w = _lowerBound[_axis] + slice*dw;
+    
+    Point p;
+    Point vu,vv;
+    switch (_axis) {
+      case 0: p=Point(w,u,v); vu=Point(0,du,0); vv=Point(0,0,dv);break;
+      case 1: p=Point(u,w,v); vu=Point(du,0,0); vv=Point(0,0,dv);break;
+      case 2: p=Point(u,v,w); vu=Point(du,0,0); vv=Point(0,dv,0);break;
+    }
+    
+    std::vector<Point> vertices(_nbSteps*_nbSteps);
+    std::vector<double> values(_nbSteps*_nbSteps);
+    for(size_t id=0; id < _nbSteps*_nbSteps; ++id)
+    {
+      auto i = id % _nbSteps;
+      auto j = id / _nbSteps;
+      p = _lowerBound + i*vu + j*vv;
+      vertices[id] = p;
+      values[id]  = _implicit(p);
+    }
+    //auto psm = polyscope::registerSurfaceMesh("Slice "+std::to_string(axis), vertices,faces);
+    polyscope::getSurfaceMesh(_name)->updateVertexPositions(vertices);
+    polyscope::getSurfaceMesh(_name)->addVertexDistanceQuantity("values",values);
+  }
+};
+
+
+
+template<typename Point, typename Functor>
+PolyscopeSlicer<Point,Functor> makeSlicer(std::string name,
+                                          Functor & implicit,
+                                          const Point &lowerBound,
+                                          const Point &upperBound,
+                                          size_t nbSteps,
+                                          size_t axis)
+{
+  return PolyscopeSlicer<Point,Functor>(name,
+                                        implicit,
+                                        lowerBound,
+                                        upperBound,
+                                        nbSteps,
+                                        axis);
+}

--- a/src/polyscopeSlicer.hpp
+++ b/src/polyscopeSlicer.hpp
@@ -1,3 +1,28 @@
+//MIT License
+//
+//Copyright (c) 2023 Ponca Development Group
+//
+//        Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//        copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//        copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+/// \file This file contains a slicer of the implicit function as a Polyscope surface mesh
+/// \author David Coeurjolly <david.coeurjolly@cnrs.fr >
+
 #pragma once
 #include <vector>
 #include <array>
@@ -24,8 +49,8 @@
  * @return a pointer to the polyscope surface mesh object
  */
 template<typename Point,typename Functor>
-polyscope::SurfaceMesh* registerRegularSlicer(std::string name,
-                                              Functor &implicit,
+polyscope::SurfaceMesh* registerRegularSlicer(const std::string &name,
+                                              const Functor &implicit,
                                               const Point &lowerBound,
                                               const Point &upperBound,
                                               size_t nbSteps,
@@ -72,11 +97,12 @@ polyscope::SurfaceMesh* registerRegularSlicer(std::string name,
       faces.push_back(face);
   }
   
-  //Evaluatng the mplicit function (in parallel)
+  //Evaluating the mplicit function (in parallel using openmp)
 #pragma omp parallel for
   for(size_t id=0; id < nbSteps*nbSteps; ++id)
     values[id]  = implicit(vertices[id]);
 
+  //Polyscope registration
   auto psm = polyscope::registerSurfaceMesh(name, vertices,faces);
   psm->addVertexScalarQuantity("values",values)->setEnabled(true);
   return psm;


### PR DESCRIPTION
Add a generic (regular) slicer in polyscope.

Note that if openmp is activated, the implicit function evaluations are computed in //


<img width="662" alt="Capture d’écran 2023-12-09 à 17 48 37" src="https://github.com/poncateam/poncascope/assets/700165/68fc6679-fa19-45c7-9e08-3fe7d38e59e9">
